### PR TITLE
Fix Ecto format function infinite recursion loop

### DIFF
--- a/test/pretty_print_formatter/ecto_test.exs
+++ b/test/pretty_print_formatter/ecto_test.exs
@@ -122,6 +122,8 @@ defmodule PrettyPrintFormatter.EctoTest do
 
       assert select_message_one_arg ==
         "SELECT id FROM users"
+
+      assert "SELECT a, b (4 more) FROM users AS u0 where u0.id = 5" == "SELECT a, b, c, d, e, f FROM users AS u0 where u0.id = 5" |> statement_message
     end
   end
 


### PR DESCRIPTION
Fix an infinite recursion when the query `"SELECT a, b, c, d, e, f FROM users AS u0 where u0.id = 5"` is formatted.

Also update format/3 private function from PrettyPrintFormatter.Ecto to be tailless recursive.